### PR TITLE
修正无验证集输入时的代码报错问题

### DIFF
--- a/pypi/fastbert/fastbert.py
+++ b/pypi/fastbert/fastbert.py
@@ -433,7 +433,7 @@ class FastBERT(nn.Module):
                 scheduler.step()
 
             dev_acc, _ = self._evaluate(sentences_dev, labels_dev, speed=0.0) \
-                    if dev_num > 0 else 0.0
+                    if dev_num > 0 else (0.0, 0.0)
             train_acc, _ = self._evaluate(sentences_train, labels_train, speed=0.0)
             if verbose:
                 print("[FastBERT]: Evaluating at fine-tuning epoch {}/{}".\
@@ -544,7 +544,7 @@ class FastBERT(nn.Module):
                 scheduler.step()
 
             dev_acc, ave_layers = self._evaluate(sentences_dev, labels_dev, speed=0.5) \
-                    if dev_num > 0 else 0.0
+                    if dev_num > 0 else (0.0, 0)
             print("[FastBERT]: Evaluating at self-disilling epoch {}/{}".\
                     format(epoch+1, epochs_num),
                     "dev_acc = {:.3f}, ave_exec_layers = {:.3f}".format(dev_acc, ave_layers))


### PR DESCRIPTION
作者您好，我在使用您封装好的FastBERT进行单句子文本分类的实验时，在未输入验证集的情况下，在一个epoch训练结束时，报错“TypeError: cannot unpack non-iterable float object”。位置位于fastbert.py文件436行，我发现为变量赋值问题导致，具体请查阅PR。